### PR TITLE
make sure to import own script's macro for compatibility with twig 2

### DIFF
--- a/Resources/views/Default/show.html.twig
+++ b/Resources/views/Default/show.html.twig
@@ -33,19 +33,20 @@
             <li><a href="#similar" data-toggle="tab">{{ 'log.show.similar' | trans }} {{ utils.render_count_badge(similar_logs | length) }}</a></li>
         </ul>
         <div class="tab-content">
+            {% import _self as show_macros %}
             <div class="tab-pane active" id="extra">
-                {{ _self.render_data_table(log.extra) }}
+                {{ show_macros.render_data_table(log.extra) }}
             </div>
             <div class="tab-pane" id="context">
-                {{ _self.render_data_table(log.context) }}
+                {{ show_macros.render_data_table(log.context) }}
             </div>
             <div class="tab-pane" id="request">
                 <h2>SERVER</h2>
-                {{ _self.render_data_table(log.serverData) }}
+                {{ show_macros.render_data_table(log.serverData) }}
                 <h2>POST</h2>
-                {{ _self.render_data_table(log.postData) }}
+                {{ show_macros.render_data_table(log.postData) }}
                 <h2>GET</h2>
-                {{ _self.render_data_table(log.getData) }}
+                {{ show_macros.render_data_table(log.getData) }}
             </div>
             <div class="tab-pane" id="similar">
                 {% if similar_logs | length %}


### PR DESCRIPTION
Twig 2 won't allow direct access to `_self` - macros in the current template need to be explicitly imported.

see: http://twig.sensiolabs.org/doc/tags/macro.html

This throws deprecation warnings now when using current versions of Twig. 